### PR TITLE
Update dlg_lexers_compare.py

### DIFF
--- a/dlg_lexers_compare.py
+++ b/dlg_lexers_compare.py
@@ -10,7 +10,7 @@ class DlgLexersCompare:
     def __init__(self, data=None):
         self.data = data
         self.items = list(self.data.get('files', {}).keys())
-        self.lexers = ct.lexer_proc(ct.LEXER_GET_LEXERS, False)
+        self.lexers = ct.lexer_proc(ct.LEXER_GET_LEXERS, True)
         self.state = {k: '-1;' + ','*len(self.lexers) for k in self.items}
 
         w, h = 600, 400


### PR DESCRIPTION
вывод скрытых лексеров, к примеру, PHP_ - для выбора его при установке сниппетов
иначе не работают сниппеты в php-файлах
т.к. в config.json в блок snippets.json добавляется только PHP